### PR TITLE
Fixed wrong link for Greensock library

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,6 @@
 
 - [Isomer - isometric game library](http://jdan.github.io/isomer/)
 - [Matter - 2D physics library](http://brm.io/matter-js/)
-- [GreenSock - 2D animation library](http://brm.io/matter-js/)
+- [GreenSock - 2D animation library](https://greensock.com/)
 - [Pixi.js - canvas rendering library](http://www.pixijs.com)
 - [ThreeJS - 3D rendering engine](https://threejs.org)


### PR DESCRIPTION
De link van de greensock library linkt naar de docs voor Matter.js.